### PR TITLE
gitignoreの更新、configフォルダの作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+config/


### PR DESCRIPTION
configフォルダ内にDB接続用ファイルを作成

# やったこと

configフォルダをGitHubにあげないようにgitignoreファイルを更新
configフォルダ内にdb_connectファイルを作成

# 各種リンク

なし

# キャプチャ

なし

# 備考

特になし