### PR TITLE
アプリ一覧画面の作成

### DIFF
--- a/src/components/Header.php
+++ b/src/components/Header.php
@@ -5,5 +5,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <title> </title>
         <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+        <link rel="stylesheet" href="../css/AppList.css">
     </head>
     <body>

--- a/src/css/AppList.css
+++ b/src/css/AppList.css
@@ -1,0 +1,27 @@
+@charset "utf-8";
+
+.AppList_wrap {
+    display: flex;
+    margin: 1rem;
+}
+
+.AppList_content {
+    width: 25%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 1rem;
+}
+
+.AppList_img {
+    width: 4rem;
+    height: auto;
+    border-radius: 10px;
+    margin-bottom: .5rem;
+}
+
+.AppList_p {
+    overflow-wrap: normal;
+    font-size: .8rem;
+    text-align: center;
+}

--- a/src/features/AppList/getAppInfo.php
+++ b/src/features/AppList/getAppInfo.php
@@ -1,14 +1,14 @@
 <?php
-    require_once '../../config/db-connect.php';
-    
-    function getAppList() {
-        global $pdo;
-        $sql = $pdo->query('
+require_once '/home/users/2/verse.jp-aso2201030/web/AppEcho/config/db_connect.php';
+
+function getAppList()
+{
+    global $pdo;
+    $sql = $pdo->query('
             SELECT app.id, app.name, app.image_url, app.keyword, category.name AS category_name
-            FROM app 
-            INNER JOIN category 
+            FROM app
+            INNER JOIN category
             ON app.category_id = category.id
         ');
-        return $sql->fetchAll();
-    }
-?>
+    return $sql->fetchAll();
+}

--- a/src/pages/AppList.php
+++ b/src/pages/AppList.php
@@ -7,11 +7,10 @@ $AppList = getAppList();
 <div class="AppList_wrap">
 
     <?php
-    $cnt = 0;
     foreach ($AppList as $app) {
     ?>
         <div class="AppList_content">
-            <img class="AppList_img" src="<?php echo $app['image_url'] ?>" alt="<?php echo $app['name'] ?>">
+            <a href="#"><img class="AppList_img" src="<?php echo $app['image_url'] ?>" alt="<?php echo $app['name'] ?>"></a>
             <p class="AppList_p"><?php echo $app['name'] ?></p>
         </div>
     <?php

--- a/src/pages/AppList.php
+++ b/src/pages/AppList.php
@@ -1,14 +1,25 @@
 <?php
-    require_once '../components/Header.php';
-    require_once '../features/AppList/getAppInfo.php';
-    $AppList = getAppList();
+require_once '../components/Header.php';
+require_once '../features/AppList/getAppInfo.php';
+$AppList = getAppList();
 ?>
 
-<?php foreach ($AppList as $app) { ?>
-    <img src="<?php echo $app['image_url'] ?>" alt="">
-    <p><?php echo $app['name'] ?></p>
-<?php } ?>
+<div class="AppList_wrap">
+
+    <?php
+    $cnt = 0;
+    foreach ($AppList as $app) {
+    ?>
+        <div class="AppList_content">
+            <img class="AppList_img" src="<?php echo $app['image_url'] ?>" alt="<?php echo $app['name'] ?>">
+            <p class="AppList_p"><?php echo $app['name'] ?></p>
+        </div>
+    <?php
+    }
+    ?>
+
+</div>
 
 <?php
-    require_once '../components/Footer.php';
+require_once '../components/Footer.php';
 ?>


### PR DESCRIPTION
# やったこと

アプリ一覧画面を作成。

# 各種リンク

特になし

# キャプチャ

![aso2201030 verse jp_AppEcho_src_pages_AppList php(iPhone SE)](https://github.com/naoyuki2/AppEcho/assets/141080366/1dc067b3-f0e7-451a-92ee-5c97ecad34dc)

# 備考

サーバーで試したところgetAppInfoでエラーが出たので、db_connectの読み込みをしているコードを書き変えています。
- 枠線なし
- paddingでアプリ間の幅を取っています(1rem)
- 全体外側のマージンは1rem(16px)
- アプリの大きさは4rem(64px)
  - 4つ以上のコンテンツを並べた時にどう表示されるかの確認がいるかも