### PR TITLE
検索画面のエラー修正

### DIFF
--- a/src/features/AppSearch/AppChoice.php
+++ b/src/features/AppSearch/AppChoice.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../features/AppSearch/getAppSearch.php';
+require_once 'getAppSearch.php';
 
 if (!empty($_POST['AppName'])) {
     $text = $_POST['AppName'];
@@ -29,4 +29,4 @@ if ($appId != -1 && $appId != 0) {
     $queryString = http_build_query(['app' => 0]);
 }
 
-header('Location: ./AppList.php?'. $queryString);
+header('Location: ../../pages/AppList.php?'. $queryString);


### PR DESCRIPTION
# やったこと

AppChoice.php
(2行目をrequire_once 'getAppSearch.php';
32行目をheader('Location: ../../pages/AppList.php?'. $queryString);
に変更)

# 各種リンク

- #58 

# キャプチャ

[AppSearch.php](https://aso2201022.hacca.jp/Appecho/src/pages/AppSearch.php)https://[aso2201022.hacca.jp/Appecho/src/pages/AppSearch.php](https://aso2201022.hacca.jp/Appecho/src/pages/AppSearch.php)

# 備考
同じ書き方をしたほかの場所もエラーが起きる可能性があります