### PR TITLE
ユーザーのログイン・新規登録画面のUI作成

### DIFF
--- a/src/components/Header.php
+++ b/src/components/Header.php
@@ -21,6 +21,7 @@ $isAdmin = isset($_SESSION['admin']) && $_SESSION['admin'] === true;
     <link rel="stylesheet" href="../../css/AppSearch.css">
     <link rel="stylesheet" href="../../css/AppReviewFilter.css">
     <link rel="stylesheet" href="../../css/AppReviews-modal.css">
+    <link rel="stylesheet" href="../../css/Auth.css">
 </head>
 
 <body>

--- a/src/css/Auth.css
+++ b/src/css/Auth.css
@@ -1,0 +1,38 @@
+@charset "utf-8";
+
+.Auth-wrap {
+    margin: 1.5rem .5rem;
+}
+
+.Auth-nav {
+    --bs-nav-link-color: #4b4b4b;
+    --bs-nav-link-hover-color: #4b4b4b;
+    --bs-nav-tabs-border-color: #4b4b4b;
+    --bs-nav-tabs-link-hover-border-color: #3EA632;
+    --bs-nav-tabs-link-active-color: #3EA632;
+    --bs-nav-tabs-link-active-border-color: #3EA632;
+}
+
+.Auth-tab-content {
+    margin-top: 3rem;
+}
+
+.Auth-inputContent {
+    margin-bottom: 1.5rem;
+}
+
+.Auth-label {
+    text-align: center;
+    margin: .5rem;
+}
+
+.Auth-email, .Auth-password, .Auth-text {
+    font-size: .8rem;
+    display: flex;
+    margin: 0 auto;
+}
+
+.Auth-submit {
+    display: flex;
+    margin: 4rem auto;
+}

--- a/src/pages/user/Auth.php
+++ b/src/pages/user/Auth.php
@@ -1,0 +1,53 @@
+<?php require_once dirname(__FILE__, 3) . '/components/Header.php' ?>
+
+<div class="Auth-wrap">
+    <ul class="nav nav-tabs nav-fill Auth-nav" id="myTab" role="tablist">
+        <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="login-tab" data-bs-toggle="tab" data-bs-target="#login-tab-pane" type="button" role="tab" aria-controls="login-tab-pane" aria-selected="true">ログイン</button>
+        </li>
+        <li class="nav-item" role="presentation">
+            <button class="nav-link" id="signUp-tab" data-bs-toggle="tab" data-bs-target="#signUp-tab-pane" type="button" role="tab" aria-controls="signUp-tab-pane" aria-selected="false">新規登録</button>
+        </li>
+    </ul>
+
+    <div class="tab-content Auth-tab-content">
+        <div class="tab-pane fade show active" id="login-tab-pane" role="tabpanel" aria-labelledby="login-tab-pane" tabindex="0">
+            <form action="#" method="post">
+                <div class="Auth-inputContent">
+                    <p class="Auth-label">メールアドレス</p>
+                    <input type="email" name="email" class="Auth-email" size="30">
+                </div>
+
+                <div class="Auth-inputContent">
+                    <p class="Auth-label">パスワード</p>
+                    <input type="password" name="password" class="Auth-password" size="30">
+                </div>
+
+                <button type="submit" class="btn btn-outline-success Auth-submit">ログイン</button>
+            </form>
+        </div>
+
+        <div class="tab-pane fade" id="signUp-tab-pane" role="tabpanel" aria-labelledby="signUp-tab-pane" tabindex="0">
+            <form action="#" method="post">
+                <div class="Auth-inputContent">
+                    <p class="Auth-label">ユーザーネーム</p>
+                    <input type="text" name="text" class="Auth-text" size="30">
+                </div>
+
+                <div class="Auth-inputContent">
+                    <p class="Auth-label">メールアドレス</p>
+                    <input type="email" name="email" class="Auth-email" size="30">
+                </div>
+
+                <div class="Auth-inputContent">
+                    <p class="Auth-label">パスワード</p>
+                    <input type="password" name="password" class="Auth-password" size="30">
+                </div>
+
+                <button type="submit" class="btn btn-outline-success Auth-submit">新規登録</button>
+            </form>
+        </div>
+    </div>
+</div>
+
+<?php require_once dirname(__FILE__, 3) . '/components/Footer.php' ?>


### PR DESCRIPTION
# やったこと

- ログイン・新規登録画面の見た目を作成
- ログインと新規登録はタブで切り替える

# 各種リンク

#117 

# キャプチャ


https://github.com/naoyuki2/AppEcho/assets/141080366/661a0569-5e63-4b02-bee5-647e2697a2ff



# 備考

- パスワードの文字を隠したり見せたりするやつ
- メールアドレスのバリデーション

上記はあとでやります