### PR TITLE
ヘッダー内ユーザーアイコンの位置調整

### DIFF
--- a/src/css/Header.css
+++ b/src/css/Header.css
@@ -60,10 +60,13 @@ header {
 }
 
 .Header-user {
-  margin-right: 0.5rem;
+  margin-right: 0.2rem;
   margin-top: 0.2rem;
 }
 
 .Header-user-icon {
-  width: 2rem;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 100%;
+  object-fit: contain;
 }

--- a/src/features/UserProfile/editProfile.php
+++ b/src/features/UserProfile/editProfile.php
@@ -42,6 +42,7 @@ if (isset($userIconPass)) {
         WHERE id = ?
     ');
     $update->execute([$userName, $email, $userIconPass, $isAnonymous, $userId]);
+    $_SESSION['user']['image_url'] = $userIconPass;
 } else {
     $update = $pdo->prepare('
         UPDATE user SET name = ?, email = ?, isAnonymous = ?


### PR DESCRIPTION
# やったこと

- ヘッダー内にあるユーザーアイコンを丸く切り取った

# 各種リンク

特になし

# キャプチャ

特になし

# 備考

特になし